### PR TITLE
Fix of potential pointer misuses

### DIFF
--- a/utf16.go
+++ b/utf16.go
@@ -5,18 +5,25 @@ import (
 	"unsafe"
 )
 
-// UTF16PtrToString converts a pointer to a UTF16 string to a string
+// UTF16PtrToString converts a pointer to a UTF-16 sequence to a string.
+// The UTF-16 sequence must null terminated or shorter than maxLen.
+//
+// If the UTF-16 sequence is longer than maxlen, an empty string is returned.
 func UTF16PtrToString(ptr *uint16, maxLen int) (s string) {
 	if ptr == nil {
 		return ""
 	}
+
 	buf := make([]uint16, 0, maxLen)
-	for i, p := 0, uintptr(unsafe.Pointer(ptr)); i < maxLen; i, p = i+1, p+2 {
-		char := *(*uint16)(unsafe.Pointer(p))
+	for i, p := 0, unsafe.Pointer(ptr); i < maxLen; i, p = i+1, unsafe.Pointer(uintptr(p)+2) {
+		char := *(*uint16)(p)
 		if char == 0 {
+			// Decode sequence and return
 			return string(utf16.Decode(buf))
 		}
+
 		buf = append(buf, char)
 	}
+	// Return empty string once maxLen is reached.
 	return ""
 }

--- a/utf16_test.go
+++ b/utf16_test.go
@@ -1,0 +1,50 @@
+package websspi_test
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/quasoft/websspi"
+)
+
+const maxmaxlen = 1024
+
+var testcases = []struct {
+	utf16  []uint16
+	result string
+	maxlen int
+}{
+	{
+		utf16:  syscall.StringToUTF16("Hello World!"),
+		result: "", // empty string if sequence longer than maxlen
+		maxlen: 5,
+	},
+	{
+		utf16:  syscall.StringToUTF16("Hello World!"),
+		result: "Hello World!",
+		maxlen: maxmaxlen,
+	},
+	{
+		utf16:  []uint16{0},
+		result: "",
+		maxlen: maxmaxlen,
+	},
+	{
+		utf16:  nil,
+		result: "",
+		maxlen: maxmaxlen,
+	},
+}
+
+func TestUTF16PtrToString(t *testing.T) {
+	for i, c := range testcases {
+		var ptr *uint16
+		if c.utf16 != nil {
+			ptr = &c.utf16[0]
+		}
+
+		if r := websspi.UTF16PtrToString(ptr, c.maxlen); r != c.result {
+			t.Errorf("#%d: Got %q instead of %q", i, r, c.result)
+		}
+	}
+}

--- a/websspi_windows.go
+++ b/websspi_windows.go
@@ -254,10 +254,10 @@ func (a *Authenticator) AcceptOrContinue(context *CtxtHandle, authData []byte) (
 	if status == SEC_E_OK || status == SEC_I_CONTINUE_NEEDED {
 		// Copy outputBuf.Buffer to out and free the outputBuf.Buffer
 		out = make([]byte, outputBuf.BufferSize)
-		var bufPtr = uintptr(unsafe.Pointer(outputBuf.Buffer))
+		var bufPtr = unsafe.Pointer(outputBuf.Buffer)
 		for i := 0; i < len(out); i++ {
-			out[i] = *(*byte)(unsafe.Pointer(bufPtr))
-			bufPtr++
+			out[i] = *(*byte)(bufPtr)
+			bufPtr = unsafe.Pointer(uintptr(bufPtr) + 1)
 		}
 	}
 	if outputBuf.Buffer != nil {
@@ -443,14 +443,14 @@ func (a *Authenticator) GetUserGroups(userName string) (groups []string, err err
 		return
 	}
 
-	ptr := uintptr(unsafe.Pointer(buf))
+	ptr := unsafe.Pointer(buf)
 	for i := uint32(0); i < entriesRead; i++ {
-		groupInfo := (*GroupUsersInfo0)(unsafe.Pointer(ptr))
+		groupInfo := (*GroupUsersInfo0)(ptr)
 		groupName := UTF16PtrToString(groupInfo.Grui0_name, MAX_GROUP_NAME_LENGTH)
 		if groupName != "" {
 			groups = append(groups, groupName)
 		}
-		ptr += unsafe.Sizeof(GroupUsersInfo0{})
+		ptr = unsafe.Pointer(uintptr(ptr) + unsafe.Sizeof(GroupUsersInfo0{}))
 	}
 	return
 }


### PR DESCRIPTION
The [documentation of unsafe](https://pkg.go.dev/unsafe#Pointer) defines some patterns for a "safe" use of pointers. This pull request fixes the `go vet` warnings related to those.

I don't know if there were any practical problems by not following those patterns, as the pointers usually point to memory allocated by C, and therefore are not affected by Go's garbage collectors - and Go's GC currently does not move objects in memory anyway. 