### PR TITLE
Add linked token resolution

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+/*
+Package websspi provides middleware to require with Windows Integrated Authentication.
+*/
+package websspi

--- a/examples/server_windows.go
+++ b/examples/server_windows.go
@@ -14,16 +14,25 @@ import (
 )
 
 var helloTemplate = template.Must(template.New("index.html").Parse(`
-{{- if . -}}
-<h2>Hello {{ .Username }}!</h2>
+{{- if .User -}}
+<h2>Hello {{ .User.Username }}!</h2>
 
-{{ if .Groups -}}
+{{ if .User.Groups -}}
 Groups:
 <ul>
-{{- range .Groups}}
+{{- range .User.Groups}}
 	<li>{{ . }}</li>
 {{end -}}
 </ul>
+{{- if .Linked}}
+<h3>Linked Token: {{ .Linked.Username }}</h3>
+Groups:
+<ul>
+{{- range .Linked.Groups}}
+	<li>{{ . }}</li>
+{{end -}}
+</ul>
+{{end -}}
 {{- end }}
 {{- else -}}
 <h2>Hello!</h2>
@@ -34,6 +43,10 @@ func main() {
 	config := websspi.NewConfig()
 	config.EnumerateGroups = true // If groups should be resolved
 	// config.ServerName = "..." // If static instead of dynamic group membership should be resolved
+	config.ResolveLinked = true
+	// If a linked token should be resolved.
+	// For UAC restricted admin the linked user info will have the "all" groups.
+	// For UAC elevated user the linked user info will have the restricted ones.
 
 	auth, err := websspi.New(config)
 	if err != nil {
@@ -43,9 +56,16 @@ func main() {
 	server := &http.Server{Addr: "0.0.0.0:9000"}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		info := r.Context().Value(websspi.UserInfoKey)
+		linked := r.Context().Value(websspi.LinkedTokenUserInfoKey)
 		userInfo, _ := info.(*websspi.UserInfo)
+		linkedTokenUserInfo, _ := linked.(*websspi.UserInfo)
 		w.Header().Add("Content-Type", "text/html; encoding=utf-8")
-		helloTemplate.Execute(w, userInfo)
+		helloTemplate.Execute(w, struct {
+			User   *websspi.UserInfo
+			Linked *websspi.UserInfo
+		}{
+			userInfo, linkedTokenUserInfo,
+		})
 	})
 	http.Handle("/", auth.WithAuth(handler))
 

--- a/userinfo.go
+++ b/userinfo.go
@@ -4,4 +4,6 @@ package websspi
 type UserInfo struct {
 	Username string   // Name of user, usually in the form DOMAIN\User
 	Groups   []string // The global groups the user is a member of
+
+	linked *UserInfo
 }

--- a/websspi_test.go
+++ b/websspi_test.go
@@ -23,11 +23,20 @@ var sidRemoteDesktopUsers *syscall.SID
 var resolvedGroups []string
 var resolvedGroupsWoAdmin []string
 
+var sidAdministrator *syscall.SID
+var resolvedAdministrator string
+
 func init() {
+	me, _ := user.Current()
+	parts := strings.Split(me.Uid, "-")
+	administrator, _ := user.LookupId(strings.Join(parts[0:len(parts)-2], "-") + "-500")
+	resolvedAdministrator = administrator.Username
+
 	for stringSid, binPtr := range map[string]**syscall.SID{
-		"S-1-5-32-544": &sidAdministrators,     // BUILTIN\Administrators
-		"S-1-5-32-545": &sidUsers,              // BUILTIN\Users
-		"S-1-5-32-555": &sidRemoteDesktopUsers, // BUILTIN\Remote Desktop Users
+		administrator.Uid: &sidAdministrator,      // ...\Administrator
+		"S-1-5-32-544":    &sidAdministrators,     // BUILTIN\Administrators
+		"S-1-5-32-545":    &sidUsers,              // BUILTIN\Users
+		"S-1-5-32-555":    &sidRemoteDesktopUsers, // BUILTIN\Remote Desktop Users
 	} {
 		*binPtr, _ = syscall.StringToSid(stringSid)
 	}

--- a/websspi_windows.go
+++ b/websspi_windows.go
@@ -63,8 +63,8 @@ func (c contextKey) String() string {
 }
 
 var (
-	UserInfoKey         = contextKey("UserInfo")
-	LinkedTokenUserInfo = contextKey("LinkedTokenUserInfo")
+	UserInfoKey            = contextKey("UserInfo")
+	LinkedTokenUserInfoKey = contextKey("LinkedTokenUserInfo")
 )
 
 // The Authenticator type provides middleware methods for authentication of http requests.
@@ -342,16 +342,93 @@ func (a *Authenticator) GetUsername(context *CtxtHandle) (username string, err e
 	return
 }
 
-// GetGroups returns the groups assosiated with the specified security context
-func (a *Authenticator) GetGroups(context *CtxtHandle) (groups []string, err error) {
+// GetAccessToken returns the access token of a context handle.
+func (a *Authenticator) GetAccessToken(context *CtxtHandle) (t syscall.Token, err error) {
 	var token SecPkgContext_AccessToken
 	status := a.Config.authAPI.QueryContextAttributes(context, SECPKG_ATTR_ACCESS_TOKEN, (*byte)(unsafe.Pointer(&token)))
 	if status != SEC_E_OK {
 		err = fmt.Errorf("QueryContextAttributes failed with status 0x%x", status)
 		return
 	}
+	return syscall.Token(token.AccessToken), err
+}
 
-	return a.GetGroupsFromToken(syscall.Token(token.AccessToken))
+// GetLinkedUserInfo returns the user info of a linked token e.g. the full token when using the UAC
+func (a *Authenticator) GetLinkedUserInfo(context *CtxtHandle) (u *UserInfo, err error) {
+	var token syscall.Token
+	token, err = a.GetAccessToken(context)
+	if err != nil {
+		return
+	}
+
+	linkedUserInfo := TokenLinkedToken{}
+	var usedMemory uint32
+
+	err = a.Config.authAPI.GetTokenInformation(
+		token,
+		uint32(syscall.TokenLinkedToken),
+		(*byte)(unsafe.Pointer(&linkedUserInfo)),
+		uint32(reflect.TypeOf(linkedUserInfo).Size()),
+		&usedMemory,
+	)
+	if err != nil {
+		return
+	}
+
+	defer syscall.CloseHandle(linkedUserInfo.LinkedToken)
+	// The buffer will also store the SID, therefore more than sizeof(TokenUser) bytes are required.
+	buffer := make([]byte, 50)
+	linkedToken := syscall.Token(linkedUserInfo.LinkedToken)
+
+	err = a.Config.authAPI.GetTokenInformation(
+		token,
+		uint32(syscall.TokenUser),
+		&buffer[0],
+		uint32(len(buffer)),
+		&usedMemory,
+	)
+
+	tokenuser := (*TokenUser)(unsafe.Pointer(&buffer[0]))
+
+	if err != nil {
+		return
+	}
+
+	var stringsid string
+	stringsid, err = tokenuser.User.Sid.String()
+	if err != nil {
+		return
+
+	}
+
+	var lookedup *user.User
+	lookedup, err = user.LookupId(stringsid)
+	if err != nil {
+		return
+	}
+
+	u = &UserInfo{}
+	u.Username = lookedup.Username
+
+	if a.Config.EnumerateGroups {
+		if a.Config.ServerName == "" {
+			u.Groups, err = a.GetGroupsFromToken(linkedToken)
+		} else {
+			u.Groups, err = a.GetUserGroups(u.Username)
+		}
+	}
+
+	return
+}
+
+// GetGroups returns the groups assosiated with the specified security context
+func (a *Authenticator) GetGroups(context *CtxtHandle) (groups []string, err error) {
+	var token syscall.Token
+	token, err = a.GetAccessToken(context)
+	if err != nil {
+		return
+	}
+	return a.GetGroupsFromToken(token)
 }
 
 // GetGroupsFromToken returns the active groups of a Windows token
@@ -482,6 +559,13 @@ func (a *Authenticator) GetUserInfo(context *CtxtHandle) (*UserInfo, error) {
 		} else {
 			info.Groups, err = a.GetGroups(context)
 		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if a.Config.ResolveLinked {
+		info.linked, err = a.GetLinkedUserInfo(context)
 		if err != nil {
 			return nil, err
 		}
@@ -671,6 +755,9 @@ func (a *Authenticator) WithAuth(next http.Handler) http.Handler {
 		log.Print("Authenticated\n")
 		// Add the UserInfo value to the reqest's context
 		r = r.WithContext(context.WithValue(r.Context(), UserInfoKey, user))
+		if user.linked != nil {
+			r = r.WithContext(context.WithValue(r.Context(), LinkedTokenUserInfoKey, user.linked))
+		}
 		// and to the request header with key Config.AuthUserKey
 		if a.Config.AuthUserKey != "" {
 			r.Header.Set(a.Config.AuthUserKey, user.Username)

--- a/win32_windows.go
+++ b/win32_windows.go
@@ -18,6 +18,10 @@ type TokenLinkedToken struct {
 	LinkedToken syscall.Handle
 }
 
+type TokenUser struct {
+	User syscall.SIDAndAttributes
+}
+
 // secur32.dll
 
 type SECURITY_STATUS syscall.Errno

--- a/win32_windows.go
+++ b/win32_windows.go
@@ -14,6 +14,10 @@ type TokenGroups struct {
 	Groups     syscall.SIDAndAttributes // *SIDAndAttributes[]
 }
 
+type TokenLinkedToken struct {
+	LinkedToken syscall.Handle
+}
+
 // secur32.dll
 
 type SECURITY_STATUS syscall.Errno


### PR DESCRIPTION
By setting `(websspi.Config).ResolveLinked` there will be another `*websspi.UserInfo` placed in the request context with the key `websspi.LinkedTokenUserInfoKey`.

The example is extended to return both, the regular and linked token (emphasis is not in the example):

> <h2>Hello BIEWALD\Administrator!</h2>
> 
> Groups:
> <ul>
> 	<li>Domain Users</li>
> 	<li>Everyone</li>
> 	<li>Users</li>
> 	<li>INTERACTIVE</li>
> 	<li>CONSOLE LOGON</li>
> 	<li>Authenticated Users</li>
> 	<li>This Organization</li>
> 	<li>LOCAL</li>
> 	<li>Security</li>
> 	<li>Authentication authority asserted identity</li>
> 	<li>Denied RODC Password Replication Group</li>
> </ul>
> <h3>Linked Token: BIEWALD\Administrator</h3>
> Groups:
> <ul>
> 	<li>Domain Users</li>
> 	<li>Everyone</li>
> 	<li><b>Administrators</b></li>
> 	<li>Users</li>
> 	<li><b>Pre-Windows 2000 Compatible Access</b></li>
> 	<li>INTERACTIVE</li>
> 	<li>CONSOLE LOGON</li>
> 	<li>Authenticated Users</li>
> 	<li>This Organization</li>
> 	<li>LOCAL</li>
> 	<li><b>Domain Admins</b></li>
> 	<li>Security</li>
> 	<li><b>Group Policy Creator Owners</b></li>
> 	<li><b>Enterprise Admins</b></li>
> 	<li><b>Schema Admins</b></li>
> 	<li>Authentication authority asserted identity</li>
> 	<li>Denied RODC Password Replication Group</li>
> </ul>

If the same site is requested from an elevated command, the tokens are swapped. Tests and improved documentation is missing, hence the draft status of this PR. 

Closes #5.